### PR TITLE
과제 목록 API 수정

### DIFF
--- a/src/main/java/sookmyung/moaroom/Controller/AssignmentController.java
+++ b/src/main/java/sookmyung/moaroom/Controller/AssignmentController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import sookmyung.moaroom.Dto.requestAssignmentDto;
+import sookmyung.moaroom.Dto.responseAssignmentDto;
 import sookmyung.moaroom.Model.Assignment;
 import sookmyung.moaroom.Model.Url;
 import sookmyung.moaroom.Service.AssignmentService;
@@ -26,9 +27,9 @@ public class AssignmentController {
         return assignmentService.modify(id, existAssignment);
     }
 
-    @GetMapping("/assignment/all")
-    public List<Assignment> allLecture(){
-        return assignmentService.findAll();
+    @GetMapping("/assignment/all/{user_id}")
+    public List<responseAssignmentDto> allLecture(@PathVariable("user_id") String id){
+        return assignmentService.findAll(id);
     }
 
     @GetMapping("/assignment/{assignment_id}")

--- a/src/main/java/sookmyung/moaroom/Controller/AssignmentController.java
+++ b/src/main/java/sookmyung/moaroom/Controller/AssignmentController.java
@@ -37,9 +37,9 @@ public class AssignmentController {
         return assignmentService.findOne(id);
     }
 
-    @DeleteMapping("/assignment/{assignment_id}")
-    public String deleteAssignment(@PathVariable("assignment_id") String id){
-        return assignmentService.delete(id);
+    @DeleteMapping("/assignment/{assignment_title}")
+    public String deleteAssignment(@PathVariable("assignment_title") String title){
+        return assignmentService.delete(title);
     }
 
     @GetMapping("/assignment/list/{assignment_id}")

--- a/src/main/java/sookmyung/moaroom/Dto/responseAssignmentDto.java
+++ b/src/main/java/sookmyung/moaroom/Dto/responseAssignmentDto.java
@@ -1,0 +1,21 @@
+package sookmyung.moaroom.Dto;
+
+import com.sun.istack.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+public class responseAssignmentDto {
+    @NotNull
+    private UUID lecture_id;
+    @NotNull
+    private UUID assignment_id;
+    @NotNull
+    private String title;
+    @NotNull
+    private Integer step;
+    private Integer score;
+}

--- a/src/main/java/sookmyung/moaroom/Respository/AssignmentRepository.java
+++ b/src/main/java/sookmyung/moaroom/Respository/AssignmentRepository.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 public interface AssignmentRepository extends JpaRepository<Assignment, AssignmentPK> {
     public Assignment findByAssignmentId(UUID assignmentId);
     @Transactional
-    public void deleteByAssignmentId(UUID assignmentId);
+    public void deleteByTitle(String title);
 }

--- a/src/main/java/sookmyung/moaroom/Respository/StepRepository.java
+++ b/src/main/java/sookmyung/moaroom/Respository/StepRepository.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 @Repository
 public interface StepRepository extends JpaRepository<Step, StepPK> {
 
-    public List<Step> findByAssignmentId(UUID assinmentId);
+    public List<Step> findByUserId(UUID userId);
 }

--- a/src/main/java/sookmyung/moaroom/Service/AssignmentService.java
+++ b/src/main/java/sookmyung/moaroom/Service/AssignmentService.java
@@ -169,13 +169,9 @@ public class AssignmentService {
         return null;
     }
 
-    public String delete(String id){
+    public String delete(String title){
         try {
-            if(assignmentRepository.findByAssignmentId(UUID.fromString(id)).equals(null)){
-                throw new Exception("존재하지 않는 강의");
-            }
-
-            assignmentRepository.deleteByAssignmentId(UUID.fromString(id));
+            assignmentRepository.deleteByTitle(title);
             return "삭제 성공";
         } catch (Exception e){
             return "err: "+e.getMessage();

--- a/src/main/java/sookmyung/moaroom/Service/AssignmentService.java
+++ b/src/main/java/sookmyung/moaroom/Service/AssignmentService.java
@@ -9,8 +9,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import sookmyung.moaroom.Dto.requestAssignmentDto;
+import sookmyung.moaroom.Dto.responseAssignmentDto;
 import sookmyung.moaroom.Model.*;
 import sookmyung.moaroom.Respository.AssignmentRepository;
+import sookmyung.moaroom.Respository.StepRepository;
 import sookmyung.moaroom.Respository.UrlRepository;
 
 import java.time.LocalDateTime;
@@ -23,6 +25,8 @@ import java.util.UUID;
 public class AssignmentService {
     @Autowired
     AssignmentRepository assignmentRepository;
+    @Autowired
+    StepRepository stepRepository;
     @Autowired
     UrlRepository urlRepository;
     @Autowired
@@ -124,13 +128,28 @@ public class AssignmentService {
         return null;
     }
 
-    public List<Assignment> findAll(){
+    public List<responseAssignmentDto> findAll(String user_id){
         try{
             if(assignmentRepository.findAll().isEmpty()){
                 throw new Exception("과제 없음");
             }
-            return assignmentRepository.findAll();
 
+            List<Step> stepList = stepRepository.findByUserId(UUID.fromString(user_id));
+            if(stepList != null){
+                List<responseAssignmentDto> responseAssignmentDtoList = new ArrayList<>();
+                for(int i=0; i<stepList.size(); i++){
+                    Step step = stepList.get(i);
+                    responseAssignmentDto assignmentDto = new responseAssignmentDto();
+                    Assignment assignment = assignmentRepository.findByAssignmentId(step.getAssignmentId());
+                    assignmentDto.setAssignment_id(step.getAssignmentId());
+                    assignmentDto.setStep(step.getStep());
+                    assignmentDto.setTitle(assignment.getTitle());
+                    assignmentDto.setScore(step.getScore());
+
+                    responseAssignmentDtoList.add(assignmentDto);
+                }
+                return responseAssignmentDtoList;
+            }
         } catch (Exception e){
             System.out.println("err: "+e.getMessage());
         }


### PR DESCRIPTION
## 작업 내용

resolves: #46 

## 참고 사항
강의 목록 API처럼 모든 과제 목록보다 사용자에 따라 필요한 데이터와 정보가 다르기 때문에 그에 맞춰서 수정했습니다~
"assignment/all" -> "assignment/all/{user_id}"
return되는 데이터도 바뀜
Assignment 리스트 -> responseAssingmentDto 리스트

강의 삭제의 경우, 강의 명으로 단순하게 삭제하므로 기존 코드(assignment_id기준으로 삭제)로는 삭제 불가
url 수정: "assignment/{assignment_id}" -> "assignment/{assignment_title}"

